### PR TITLE
Workaround the colorfill problem for the vertical DOS plot

### DIFF
--- a/js/lib/bands.js
+++ b/js/lib/bands.js
@@ -170,6 +170,7 @@ function bandPlot(bandDivId, bandPathTextBoxId, dataFilePaths, dosFile, showFerm
                 $("#" + bandDivId + "bt-togglePdos").addClass("button-white");
                 $("#" + bandDivId + "bt-togglePdos").removeClass("button");
 
+		// The PDOS curves start from 2. 0 is for the dumb datset of y axis. And 1 is the total DOS
                 for (var i = 2; i < theBandPlot.dosSeries.length; i++) {
                     theBandPlot.dosSeries[i].hidden = true;
                 };

--- a/js/lib/bands.js
+++ b/js/lib/bands.js
@@ -170,7 +170,7 @@ function bandPlot(bandDivId, bandPathTextBoxId, dataFilePaths, dosFile, showFerm
                 $("#" + bandDivId + "bt-togglePdos").addClass("button-white");
                 $("#" + bandDivId + "bt-togglePdos").removeClass("button");
 
-                for (var i = 1; i < theBandPlot.dosSeries.length; i++) {
+                for (var i = 2; i < theBandPlot.dosSeries.length; i++) {
                     theBandPlot.dosSeries[i].hidden = true;
                 };
                 theBandPlot.myDos.update();
@@ -179,7 +179,7 @@ function bandPlot(bandDivId, bandPathTextBoxId, dataFilePaths, dosFile, showFerm
                 $("#" + bandDivId + "bt-togglePdos").addClass("button");
                 $("#" + bandDivId + "bt-togglePdos").removeClass("button-white");
 
-                for (var i = 1; i < theBandPlot.dosSeries.length; i++) {
+                for (var i = 2; i < theBandPlot.dosSeries.length; i++) {
                     theBandPlot.dosSeries[i].hidden = false;
                 };
                 theBandPlot.myDos.update();

--- a/js/lib/bands.js
+++ b/js/lib/bands.js
@@ -170,7 +170,9 @@ function bandPlot(bandDivId, bandPathTextBoxId, dataFilePaths, dosFile, showFerm
                 $("#" + bandDivId + "bt-togglePdos").addClass("button-white");
                 $("#" + bandDivId + "bt-togglePdos").removeClass("button");
 
-		// The PDOS curves start from 2. 0 is for the dumb datset of y axis. And 1 is the total DOS
+		// The PDOS curves start from index 2. 
+		// Index 0 is for the dumb datset of y axis add to workaround the step change issue #49 . 
+		// Index 1 is for total DOS (The widget don't know if the first set of data is TDOS or not, this need to be polish in future.)
                 for (var i = 2; i < theBandPlot.dosSeries.length; i++) {
                     theBandPlot.dosSeries[i].hidden = true;
                 };

--- a/js/lib/bands.js
+++ b/js/lib/bands.js
@@ -170,8 +170,8 @@ function bandPlot(bandDivId, bandPathTextBoxId, dataFilePaths, dosFile, showFerm
                 $("#" + bandDivId + "bt-togglePdos").addClass("button-white");
                 $("#" + bandDivId + "bt-togglePdos").removeClass("button");
 
-		// The PDOS curves start from index 2. 
-		// Index 0 is for the dumb datset of y axis add to workaround the step change issue #49 . 
+		// The PDOS curves start from index 2.
+		// Index 0 is for the dumb datset of y axis add to workaround the step change issue #49 .
 		// Index 1 is for total DOS (The widget don't know if the first set of data is TDOS or not, this need to be polish in future.)
                 for (var i = 2; i < theBandPlot.dosSeries.length; i++) {
                     theBandPlot.dosSeries[i].hidden = true;

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -798,9 +798,13 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
 
     dosx.forEach(function (data, k) {
         if (orientation === 'vertical') {
-            curve.push({ x: 0, y: data - bandPlotObject.dosFermiEnergy });
+	    if (data <= bandPlotObject.dosFermiEnergy) {
+            	curve.push({ x: 0, y: data - bandPlotObject.dosFermiEnergy });
+	    };
         } else {
-            curve.push({ x: data - bandPlotObject.dosFermiEnergy, y: 0 });
+	    if (data <= bandPlotObject.dosFermiEnergy) {
+            	curve.push({ x: data - bandPlotObject.dosFermiEnergy, y: 0 });
+	    };
         };
     });
 

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -791,7 +791,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     curve = [];
 
 
-    // Here, a dumb dataset was created to represent the y axis. 
+    // Here, a dumb dataset was created to represent the y axis.
     // All the DOS curves were filled to this dumb dataset.
     var dosx = bandPlotObject.dosData['dos'][0]['x'];
     var dosy = bandPlotObject.dosData['dos'][0]['y'];
@@ -804,7 +804,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
         };
     });
 
-    // The color of the dumb dataset is white, label is 'y axis' 
+    // The color of the dumb dataset is white, label is 'y axis'
     var dos = {
         borderColor: 'white',
         hidden: false,

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -334,7 +334,7 @@ BandPlot.prototype.initDosChart = function (orientation = 'vertical') {
                     position: 'right',
                     labels: {
                         filter: function(item, chart) {
-                        // Logic to remove a particular legend item goes here
+                        // remove the label for the dumb dataset of the y axis
                             return !item.text.includes('y axis');
                         }
                     }
@@ -791,6 +791,8 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     curve = [];
 
 
+    // Here, a dumb dataset was created to represent the y axis. 
+    // All the DOS curves were filled to this dumb dataset.
     var dosx = bandPlotObject.dosData['dos'][0]['x'];
     var dosy = bandPlotObject.dosData['dos'][0]['y'];
 
@@ -802,6 +804,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
         };
     });
 
+    // The color of the dumb dataset is white, label is 'y axis' 
     var dos = {
         borderColor: 'white',
         hidden: false,

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -815,7 +815,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     });
 
     // The color of the dumb dataset is white, label is 'y axis'
-    var dos = {
+    var dumb_dos = {
         borderColor: 'white',
         hidden: false,
         borderWidth: 1,

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -848,7 +848,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
             hidden: false,
             borderWidth: 1,
             data: curve,
-            fill: '-1',
+            fill: 0,
             showLine: true,
             pointRadius: 0,
             label: bandPlotObject.dosData['dos'][i]['label'],

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -332,6 +332,12 @@ BandPlot.prototype.initDosChart = function (orientation = 'vertical') {
                 legend: {
                     display: this.showLegend,
                     position: 'right',
+                    labels: {
+                        filter: function(item, chart) {
+                        // Logic to remove a particular legend item goes here
+                            return !item.text.includes('test');
+                        }
+                    }
                 },
                 scales: {
                     xAxes: [{
@@ -784,6 +790,31 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     bandPlotObject.dosSeries = [];
     curve = [];
 
+
+    var dosx = bandPlotObject.dosData['dos'][0]['x'];
+    var dosy = bandPlotObject.dosData['dos'][0]['y'];
+
+    dosx.forEach(function (data, k) {
+        if (orientation === 'vertical') {
+            curve.push({ x: 0, y: data - bandPlotObject.dosFermiEnergy });
+        } else {
+            curve.push({ x: data - bandPlotObject.dosFermiEnergy, y: 0 });
+        };
+    });
+
+    var dos = {
+        borderColor: 'black',
+        hidden: false,
+        borderWidth: 1,
+        data: curve,
+        fill: false,
+        showLine: true,
+        pointRadius: 0,
+        label: 'test'
+    };
+
+    bandPlotObject.dosSeries.push(dos);
+
     for (let i = 0; i < bandPlotObject.dosData['dos'].length; i++) {
         curve = [];
 
@@ -804,7 +835,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
             hidden: false,
             borderWidth: 1,
             data: curve,
-            fill: true,
+            fill: '-1',
             showLine: true,
             pointRadius: 0,
             label: bandPlotObject.dosData['dos'][i]['label'],

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -803,7 +803,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     });
 
     var dos = {
-        borderColor: 'black',
+        borderColor: 'white',
         hidden: false,
         borderWidth: 1,
         data: curve,

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -826,7 +826,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
         label: 'y axis'
     };
 
-    bandPlotObject.dosSeries.push(dos);
+    bandPlotObject.dosSeries.push(dumb_dos);
 
     for (let i = 0; i < bandPlotObject.dosData['dos'].length; i++) {
         curve = [];

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -802,6 +802,8 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
     var dosx = bandPlotObject.dosData['dos'][0]['x'];
     var dosy = bandPlotObject.dosData['dos'][0]['y'];
 
+    // The dumb dataset was set to the Fermi level (<= dosFermiEnergy)
+    // So the color fill will up to the Fermi level
     dosx.forEach(function (data, k) {
         if (orientation === 'vertical') {
 	    if (data <= bandPlotObject.dosFermiEnergy) {

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -335,7 +335,7 @@ BandPlot.prototype.initDosChart = function (orientation = 'vertical') {
                     labels: {
                         filter: function(item, chart) {
                         // Logic to remove a particular legend item goes here
-                            return !item.text.includes('test');
+                            return !item.text.includes('y axis');
                         }
                     }
                 },
@@ -810,7 +810,7 @@ BandPlot.prototype.updateDosPlot = function (orientation = 'vertical') {
         fill: false,
         showLine: true,
         pointRadius: 0,
-        label: 'test'
+        label: 'y axis'
     };
 
     bandPlotObject.dosSeries.push(dos);

--- a/js/lib/bandstructure.js
+++ b/js/lib/bandstructure.js
@@ -449,6 +449,12 @@ BandPlot.prototype.initDosChart = function (orientation = 'vertical') {
                 legend: {
                     display: true,
                     position: 'right',
+                    labels: {
+                        filter: function(item, chart) {
+                        // remove the label for the dumb dataset of the y axis
+                            return !item.text.includes('y axis');
+                        }
+                    }
                 },
                 scales: {
                     yAxes: [{


### PR DESCRIPTION
The issue was caused by using "fill:true" for the DOS curves, which gives wired color fill as shown below:

![image](https://user-images.githubusercontent.com/56022756/226248656-b10585bd-9b56-4912-808c-e7aa59926a57.png)

The workaround solution is adding a dumb dataset to represent the y axis. All the DOS curves are filling color to 
the dumb dataset. We put the dumb dataset at the top of the array. So the code is "fill:'-1'". The result is shown below:
 
![image](https://user-images.githubusercontent.com/56022756/226314194-826b742d-fa19-4922-bf9e-d842815b082b.png)

The fill color is set up to the Fermi level.
